### PR TITLE
feat: Add PubSub implementation using Redis

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,21 @@
 
 
 [[projects]]
+  name = "github.com/go-redis/redis"
+  packages = [
+    ".",
+    "internal",
+    "internal/consistenthash",
+    "internal/hashtag",
+    "internal/pool",
+    "internal/proto",
+    "internal/singleflight",
+    "internal/util"
+  ]
+  revision = "f3bba01df2026fc865f7782948845db9cf44cf23"
+  version = "v6.14.1"
+
+[[projects]]
   name = "github.com/gorilla/context"
   packages = ["."]
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
@@ -16,6 +31,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4212248b7f50201de7dd825b9603236a5a9ea952519be13b46e30544213de809"
+  inputs-digest = "089f4183c7c7b92c5104885ccc91d90c118548ba9fe5b03d7b6b08ad684f0148"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,3 +2,11 @@
 [[constraint]]
   name = "github.com/gorilla/mux"
   version = "1.6.2"
+
+[[constraint]]
+  name = "github.com/go-redis/redis"
+  version = "6.14.1"
+
+[[constraint]]
+  name = "github.com/stackimpact/stackimpact-go"
+  version = "2.3.9"

--- a/chore/redis/consumer.go
+++ b/chore/redis/consumer.go
@@ -1,0 +1,34 @@
+package redis
+
+import (
+	"fmt"
+	"github.com/go-redis/redis"
+	"github.com/loredami/server/pkg/pubsub"
+	"log"
+	"net/http"
+)
+
+func main() {
+	rc := redis.NewClient(&redis.Options{Addr: "redis:6379"})
+	pubSubA, _ := pubsub.NewPubSub("A", rc)
+	pubSubB, _ := pubsub.NewPubSub("B", rc)
+	pubSubC, _ := pubsub.NewPubSub("C", rc)
+	pubSubs := map[string]*pubsub.PubSub{
+		"A": pubSubA,
+		"B": pubSubB,
+		"C": pubSubC,
+	}
+
+	for _, pubSub := range pubSubs {
+		go func(pubSub pubsub.PubSub) {
+			for {
+				fmt.Println("waiting")
+				msg, _ := pubSub.Receive()
+				fmt.Println(pubSub.Name(), " received: ", msg)
+				fmt.Println("loooooping")
+			}
+		}(*pubSub)
+	}
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/chore/redis/publisher.go
+++ b/chore/redis/publisher.go
@@ -1,0 +1,32 @@
+package redis
+
+import (
+	"fmt"
+	"github.com/go-redis/redis"
+	"github.com/loredami/server/pkg/pubsub"
+	"math/rand"
+	"time"
+)
+
+func main() {
+
+	rc := redis.NewClient(&redis.Options{Addr: "redis:6379"})
+	pubSubA, _ := pubsub.NewPubSub("A", rc)
+	pubSubB, _ := pubsub.NewPubSub("B", rc)
+	pubSubC, _ := pubsub.NewPubSub("C", rc)
+	pubSubs := map[string]*pubsub.PubSub{
+		"A": pubSubA,
+		"B": pubSubB,
+		"C": pubSubC,
+	}
+
+	for {
+		for _, pubSub := range pubSubs {
+			fmt.Println("sending")
+			msg := fmt.Sprint(rand.Int())
+			fmt.Println("Error: ", pubSub.Send(*pubsub.NewMessage(msg)))
+			fmt.Println("Sent ", msg, " to : ", pubSub.Name())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"net/http"
+	"fmt"
 	"github.com/gorilla/mux"
 	"github.com/loredami/server/pkg/auth"
-	"fmt"
 	"log"
+	"net/http"
 )
 
 func main() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,3 +31,12 @@ services:
       - "5672:5672"
     env_file:
       - .env
+
+  redis:
+    image: redis:latest
+    volumes:
+      - ./docker/redis/:/data
+    ports:
+      - "6379:6379"
+    env_file:
+      - .env

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -1,9 +1,9 @@
 package auth
 
 import (
+	"fmt"
 	"github.com/gorilla/mux"
 	"net/http"
-	"fmt"
 )
 
 func AddAuthRoutes(prefix string, router *mux.Router) {

--- a/pkg/pubsub/pubSub.go
+++ b/pkg/pubsub/pubSub.go
@@ -1,0 +1,63 @@
+package pubsub
+
+import (
+	"errors"
+	"github.com/go-redis/redis"
+)
+
+type Message struct {
+	content string
+}
+
+type PubSub struct {
+	name        string
+	redisPubSub *redis.PubSub
+	client      *redis.Client
+}
+
+func NewMessage(content string) *Message {
+	return &Message{
+		content: content,
+	}
+}
+
+func (redisMessage Message) Content() string {
+	return redisMessage.content
+}
+
+func (pubSub PubSub) Name() string {
+	return pubSub.name
+}
+
+func NewPubSub(name string, client *redis.Client) (*PubSub, error) {
+	redisPubSub := client.Subscribe(name)
+
+	if _, err := redisPubSub.Receive(); err != nil {
+		return &PubSub{}, errors.New("impossible open redisPubSub due to: " + err.Error())
+	}
+
+	return &PubSub{
+		name:        name,
+		redisPubSub: redisPubSub,
+		client:      client,
+	}, nil
+}
+
+func (pubSub PubSub) Send(message Message) error {
+	if err := pubSub.client.Publish(pubSub.name, message.Content()).Err(); err != nil {
+		return errors.New("impossible send message to redis. Due to: " + err.Error())
+	}
+
+	return nil
+}
+
+func (pubSub PubSub) Receive() (*Message, error) {
+	msg, ok := <-pubSub.redisPubSub.Channel()
+	if ok != true {
+		return &Message{}, errors.New("an error occurred when reading a message")
+	}
+
+	return &Message{
+		content: msg.Payload,
+	}, nil
+}


### PR DESCRIPTION
Some examples of the implementaion are in the chore/redis directory.
There are two files, `consumer.go` and `publisher.go`.
One will publish messages, the other one consume them.